### PR TITLE
Fix basic clippy changes, ignore unused_io_amount

### DIFF
--- a/borsh-rs/benchmarks/src/lib.rs
+++ b/borsh-rs/benchmarks/src/lib.rs
@@ -156,8 +156,7 @@ pub struct AccountId(String);
 impl Generate for String {
     fn generate<R: rand::Rng>(rng: &mut R) -> Self {
         let len: usize = rng.gen_range(5, 200);
-        let res = rng.sample_iter(&Alphanumeric).take(len).collect::<String>();
-        res
+        rng.sample_iter(&Alphanumeric).take(len).collect::<String>()
     }
 }
 

--- a/borsh-rs/borsh/src/de/mod.rs
+++ b/borsh-rs/borsh/src/de/mod.rs
@@ -185,9 +185,9 @@ impl BorshDeserialize for std::net::SocketAddr {
         let kind = u8::deserialize(reader)?;
         match kind {
             0 => std::net::SocketAddrV4::deserialize(reader)
-                .map(|addr| std::net::SocketAddr::V4(addr)),
+                .map(std::net::SocketAddr::V4),
             1 => std::net::SocketAddrV6::deserialize(reader)
-                .map(|addr| std::net::SocketAddr::V6(addr)),
+                .map(std::net::SocketAddr::V6),
             value => Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
                 format!("Invalid SocketAddr variant: {}", value),


### PR DESCRIPTION
Fixing some basic clippy warnings. Ignoring unused_io_amount for now until we move to slices with #17 