### PR TITLE
travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
   - cargo build --verbose --manifest-path=borsh-rs/Cargo.toml
   - yarn install
 
-build:
+script:
   - cargo build --verbose --manifest-path=borsh-rs/Cargo.toml
   - cargo test --verbose --manifest-path=borsh-rs/Cargo.toml
   - yarn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ branches:
 cache:
   yarn: true
   cargo: true
+  directories:
+    - borsh-rs/target
 
 before_install:
   - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
@@ -25,12 +27,10 @@ before_install:
   - sudo apt-get install -y -qq yarn
 
 install:
-  - cd borsh-rs && cargo build --verbose && cd ..
+  - cargo build --verbose --manifest-path=borsh-rs/Cargo.toml
   - yarn install
 
 build:
-  - cd borsh-rs
-  - cargo build --verbose
-  - cargo test --verbose
-  - cd ..
+  - cargo build --verbose --manifest-path=borsh-rs/Cargo.toml
+  - cargo test --verbose --manifest-path=borsh-rs/Cargo.toml
   - yarn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,33 @@ rust:
   - beta
   - nightly-2019-05-22
   - nightly
+
 matrix:
   allow_failures:
     - rust: nightly
   fast_finish: true
+
+branches:
+  only:
+  - master
+
+cache:
+  yarn: true
+  cargo: true
+
 before_install:
+  - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
+  - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+  - sudo apt-get update -qq
+  - sudo apt-get install -y -qq yarn
+
+install:
+  - cd borsh-rs && cargo build --verbose && cd ..
+  - yarn install
+
+build:
   - cd borsh-rs
-cache: cargo
+  - cargo build --verbose
+  - cargo test --verbose
+  - cd ..
+  - yarn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: rust
+rust:
+  - stable
+  - beta
+  - nightly-2019-05-22
+  - nightly
+matrix:
+  allow_failures:
+    - rust: nightly
+  fast_finish: true
+before_install:
+  - cd borsh-rs
+cache: cargo

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
     <a href="https://crates.io/crates/borsh"><img src="https://img.shields.io/crates/d/borsh.svg?style=flat-square" alt="Download" /></a>
     <a href="https://discord.gg/gBtUFKR"><img src="https://img.shields.io/discord/490367152054992913.svg" alt="Join the community on Discord" /></a>
     <a href="https://opensource.org/licenses/Apache-2.0"> <img src="https://img.shields.io/badge/license-Apache2.0-blue.svg" alt="Apache 2.0 License" /></a>
-    [![Build Status](https://travis-ci.com/nearprotocol/borsh.svg?branch=master)](https://travis-ci.com/nearprotocol/borsh)
+    <a href="https://travis-ci.com/nearprotocol/borsh"><img src="https://travis-ci.com/nearprotocol/borsh.svg?branch=master" alt="Travis Build" /></a>
   </p>
   
   <h3>

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
     <a href="https://crates.io/crates/borsh"><img src="https://img.shields.io/crates/d/borsh.svg?style=flat-square" alt="Download" /></a>
     <a href="https://discord.gg/gBtUFKR"><img src="https://img.shields.io/discord/490367152054992913.svg" alt="Join the community on Discord" /></a>
     <a href="https://opensource.org/licenses/Apache-2.0"> <img src="https://img.shields.io/badge/license-Apache2.0-blue.svg" alt="Apache 2.0 License" /></a>
+    [![Build Status](https://travis-ci.com/nearprotocol/borsh.svg?branch=master)](https://travis-ci.com/nearprotocol/borsh)
   </p>
   
   <h3>


### PR DESCRIPTION
Doing this both as a CI setup and a experiment before setup travis for nearcore. So advantage: easy matrix build, easy to cache. Although not support multiple language test out of box, it's easy to setup with help of yarn's doc, nicely integrated with github, external contributor will trigger build too.

> Disadvantage: doesn't not support multiple job per repo, (multi .travis.yml file or define more than one job in single .travis.yml). This disallow us to manually run time consuming integration tests in nearcore. My suggestion is only use travis for automatic tests. Keep gitlab ci for only those manually triggered tests, since this part is always triggered by us, external contributor issue doesn't exist.

Update: Found a workround for manual build. travis just add this m anually build feature: 
![image](https://user-images.githubusercontent.com/13259400/65627688-bbbe5180-df84-11e9-8ee6-070cbbe476e4.png)
The problem is you need to paste custom yaml (it won't take the .travis.yml config in code base), but this does give you a way to manually run time consuming task.

For multiple job per repo, travis is identical to gitlab, have one .travis.yml (.gitlab.ci) which defines a pipeline, then multiple stages and different job in different stage. stage is sequential and job in same stage is parallel. stage/job can be guard with conditions too so no disadvantage and we can moving away from gitlab.