### PR TITLE
Fix string alloc

### DIFF
--- a/borsh-rs/Cargo.lock
+++ b/borsh-rs/Cargo.lock
@@ -27,7 +27,7 @@ name = "benchmarks"
 version = "0.1.0"
 dependencies = [
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "borsh 0.2.6",
+ "borsh 0.2.7",
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xorshift 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -54,22 +54,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "borsh"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
- "borsh-derive 0.2.6",
+ "borsh-derive 0.2.7",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
- "borsh-derive-internal 0.2.6",
+ "borsh-derive-internal 0.2.7",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "borsh-derive-internal"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/borsh-rs/borsh-derive-internal/Cargo.toml
+++ b/borsh-rs/borsh-derive-internal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "borsh-derive-internal"
-version = "0.2.6"
+version = "0.2.7"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/borsh-rs/borsh-derive/Cargo.toml
+++ b/borsh-rs/borsh-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "borsh-derive"
-version = "0.2.6"
+version = "0.2.7"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -16,6 +16,6 @@ Binary Object Representation Serializer for Hashing
 proc-macro = true
 
 [dependencies]
-borsh-derive-internal = { path = "../borsh-derive-internal" , version="0.2.6"}
+borsh-derive-internal = { path = "../borsh-derive-internal" , version="0.2.7"}
 syn = {version = "1", features = ["full", "fold"] }
 

--- a/borsh-rs/borsh/Cargo.toml
+++ b/borsh-rs/borsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "borsh"
-version = "0.2.6"
+version = "0.2.7"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ Binary Object Representation Serializer for Hashing
 """
 
 [dependencies]
-borsh-derive = { path = "../borsh-derive", version = "0.2.6" }
+borsh-derive = { path = "../borsh-derive", version = "0.2.7" }
 
 [features]
 default = ["std"]

--- a/borsh-rs/borsh/src/de/mod.rs
+++ b/borsh-rs/borsh/src/de/mod.rs
@@ -109,8 +109,11 @@ impl BorshDeserialize for String {
     #[inline]
     fn deserialize<R: Read>(reader: &mut R) -> Result<Self, Error> {
         let len = u32::deserialize(reader)?;
-        let mut result = vec![0; len as usize];
-        reader.read_exact(&mut result)?;
+        // TODO(16): return capacity allocation when we have the size of the buffer left from the reader.
+        let mut result = Vec::new();
+        for _ in 0..len {
+            result.push(u8::deserialize(reader)?);
+        }
         String::from_utf8(result)
             .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err.to_string()))
     }

--- a/borsh-rs/borsh/tests/test_de_errors.rs
+++ b/borsh-rs/borsh/tests/test_de_errors.rs
@@ -49,6 +49,12 @@ fn test_invalid_length() {
 }
 
 #[test]
+fn test_invalid_length_string() {
+    let bytes = vec![255u8; 4];
+    assert_eq!(String::try_from_slice(&bytes).unwrap_err().to_string(), "failed to fill whole buffer");
+}
+
+#[test]
 fn test_non_utf_string() {
     let bytes = vec![1, 0, 0, 0, 0xC0];
     assert_eq!(String::try_from_slice(&bytes).unwrap_err().to_string(), "invalid utf-8 sequence of 1 bytes from index 0");


### PR DESCRIPTION
Unsafe string allocation, for now put a slow fix to make it safe.
Need to switch reader that supports length of buffer left to optimize performance.