### PR TITLE
Remove serde for uzise/isize implementation

### DIFF
--- a/borsh-rs/benchmarks/src/lib.rs
+++ b/borsh-rs/benchmarks/src/lib.rs
@@ -4,7 +4,6 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use rand::distributions::{Alphanumeric, Distribution, Standard};
 use rand::Rng;
 use serde::{Deserialize as SerdeDeserialize, Serialize as SerdeSerialize};
-#[macro_use]
 extern crate speedy_derive;
 use speedy::{Context, Readable, Reader, Writable, Writer};
 

--- a/borsh-rs/borsh/src/de/mod.rs
+++ b/borsh-rs/borsh/src/de/mod.rs
@@ -51,12 +51,10 @@ impl_for_integer!(i16);
 impl_for_integer!(i32);
 impl_for_integer!(i64);
 impl_for_integer!(i128);
-impl_for_integer!(isize);
 impl_for_integer!(u16);
 impl_for_integer!(u32);
 impl_for_integer!(u64);
 impl_for_integer!(u128);
-impl_for_integer!(usize);
 
 // Note NaNs have a portability issue. Specifically, signalling NaNs on MIPS are quiet NaNs on x86,
 // and vice-versa. We disallow NaNs to avoid this issue.

--- a/borsh-rs/borsh/src/ser/mod.rs
+++ b/borsh-rs/borsh/src/ser/mod.rs
@@ -38,12 +38,11 @@ impl_for_integer!(i16);
 impl_for_integer!(i32);
 impl_for_integer!(i64);
 impl_for_integer!(i128);
-impl_for_integer!(isize);
 impl_for_integer!(u16);
 impl_for_integer!(u32);
 impl_for_integer!(u64);
 impl_for_integer!(u128);
-impl_for_integer!(usize);
+
 
 // Note NaNs have a portability issue. Specifically, signalling NaNs on MIPS are quiet NaNs on x86,
 // and vice-versa. We disallow NaNs to avoid this issue.


### PR DESCRIPTION
Removed case using these types could lead inconsistency b/w target architectures (don't think there is any use cases for using theses anyway).