### PR TITLE
Fully qualify std::result::Result in derives

### DIFF
--- a/borsh-rs/borsh-derive-internal/src/enum_de.rs
+++ b/borsh-rs/borsh-derive-internal/src/enum_de.rs
@@ -64,7 +64,7 @@ pub fn enum_de(input: &ItemEnum) -> syn::Result<TokenStream2> {
     if let Some(method_ident) = init_method {
         Ok(quote! {
             impl #generics borsh::de::BorshDeserialize for #name #generics where  #deserializable_field_types {
-                fn deserialize<R: std::io::Read>(reader: &mut R) -> Result<Self, std::io::Error> {
+                fn deserialize<R: std::io::Read>(reader: &mut R) -> std::result::Result<Self, std::io::Error> {
                     #variant_idx
                     let mut return_value = match variant_idx {
                         #variant_arms
@@ -82,7 +82,7 @@ pub fn enum_de(input: &ItemEnum) -> syn::Result<TokenStream2> {
     } else {
         Ok(quote! {
             impl #generics borsh::de::BorshDeserialize for #name #generics where  #deserializable_field_types {
-                fn deserialize<R: std::io::Read>(reader: &mut R) -> Result<Self, std::io::Error> {
+                fn deserialize<R: std::io::Read>(reader: &mut R) -> std::result::Result<Self, std::io::Error> {
                     #variant_idx
                     let return_value = match variant_idx {
                         #variant_arms

--- a/borsh-rs/borsh-derive-internal/src/enum_ser.rs
+++ b/borsh-rs/borsh-derive-internal/src/enum_ser.rs
@@ -69,7 +69,7 @@ pub fn enum_ser(input: &ItemEnum) -> syn::Result<TokenStream2> {
     }
     Ok(quote! {
         impl #generics borsh::ser::BorshSerialize for #name #generics where #serializable_field_types {
-            fn serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
+            fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::result::Result<(), std::io::Error> {
                 match self {
                     #body
                 }

--- a/borsh-rs/borsh-derive-internal/src/struct_de.rs
+++ b/borsh-rs/borsh-derive-internal/src/struct_de.rs
@@ -54,7 +54,7 @@ pub fn struct_de(input: &ItemStruct) -> syn::Result<TokenStream2> {
     if let Some(method_ident) = init_method {
         Ok(quote! {
             impl #generics borsh::de::BorshDeserialize for #name #generics where #deserializable_field_types {
-                fn deserialize<R: std::io::Read>(reader: &mut R) -> Result<Self, std::io::Error> {
+                fn deserialize<R: std::io::Read>(reader: &mut R) -> std::result::Result<Self, std::io::Error> {
                     let mut return_value = #return_value;
                     return_value.#method_ident();
                     Ok(return_value)
@@ -64,7 +64,7 @@ pub fn struct_de(input: &ItemStruct) -> syn::Result<TokenStream2> {
     } else {
         Ok(quote! {
             impl #generics borsh::de::BorshDeserialize for #name #generics where #deserializable_field_types {
-                fn deserialize<R: std::io::Read>(reader: &mut R) -> Result<Self, std::io::Error> {
+                fn deserialize<R: std::io::Read>(reader: &mut R) -> std::result::Result<Self, std::io::Error> {
                     Ok(#return_value)
                 }
             }


### PR DESCRIPTION
This allows `borsh` to be used with custom `Result` types like [anyhow::Result](https://docs.rs/anyhow/1.0.19/anyhow/type.Result.html).